### PR TITLE
Update main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "brace",
   "version": "0.1.2",
   "description": "browserify compatible version of the ace editor.",
-  "main": "brace.js",
+  "main": "index.js",
   "scripts": {
     "test": "browserify test/*.js > test/bundle.js --debug && opener test/index.html"
   },


### PR DESCRIPTION
Minor change to make the `main` field in the `package.json` point to the right file, `index.js`.

I ran into an issue when using a new version of `browserify` where it couldn't find this because the file didn't exist.

I think `browserify` should probably handle this like `node` does and just default to `index.js` but that's one for them I guess.
