### PR TITLE
Get w3c-blob from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/brace",
   "dependencies": {
-    "w3c-blob": "thlorenz/w3c-blob"
+    "w3c-blob": "0.0.1"
   },
   "devDependencies": {
     "uglify-js": "~2.2.5",


### PR DESCRIPTION
The w3c-blob in npm is the exact same code, but doesn't require git to install and is thus faster & more reliable.
