### PR TITLE
take mode

### DIFF
--- a/mode/take.js
+++ b/mode/take.js
@@ -1,0 +1,48 @@
+ace.define('ace/mode/take_highlight_rules',['require','exports','module','ace/lib/oop','ace/mode/text_highlight_rules'], function(acequire, exports, module) {
+
+'use strict';
+var oop = acequire('../lib/oop');
+var TextHighlightRules = acequire('./text_highlight_rules').TextHighlightRules;
+
+var TakeHighlightRules = function() {
+  this.$rules = {
+    'start': [{
+      token: 'take-complete',
+      regex: /\[.*?\]/
+    },
+    { 
+      token: 'take-open',
+      regex: /\[.*/
+    }]
+  };
+};
+
+oop.inherits(TakeHighlightRules, TextHighlightRules);
+exports.TakeHighlightRules = TakeHighlightRules;
+});
+
+ace.define('ace/mode/take',['require','exports','module','ace/lib/oop','ace/mode/text','ace/mode/json_highlight_rules','ace/mode/matching_brace_outdent','ace/mode/behaviour/cstyle','ace/mode/folding/cstyle','ace/worker/worker_client'], function(acequire, exports, module) {
+'use strict';
+
+var oop = acequire('../lib/oop');
+var TakeHighlightRules = acequire('./take_highlight_rules').TakeHighlightRules;
+var TextMode = acequire('./text').Mode;
+var Behaviour = acequire('./behaviour').Behaviour;
+
+var Mode = function() {
+    this.HighlightRules = TakeHighlightRules;
+    this.$behaviour = new Behaviour();
+};
+
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.type = 'text';
+    this.getNextLineIndent = function() {
+        return '';
+    };
+    this.$id = 'ace/mode/take';
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});

--- a/theme/take.js
+++ b/theme/take.js
@@ -1,0 +1,14 @@
+ace.define("ace/theme/take",["require","exports","module","ace/lib/dom"], function(acequire, exports, module) {
+
+exports.isDark = false;
+exports.cssClass = "ace-take";
+exports.cssText = ".ace-take .ace_take-open {\
+color: #00f\
+}\
+.ace-take .ace_take-complete {\
+color: #f00;\
+}";
+
+var dom = acequire("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});


### PR DESCRIPTION
This is a custom mode we want to implement in our new editor (where we're using brace as we browserify our entire front end).

I realize its trivial, but it's either that or forking and publishing a custom version of brace on NPM or writing some crazy postinstall script to inject these two files into the brace dependency.

Happy to look into both, but this is the lowest friction for us...