### PR TITLE
Allow using a custom build of Ace

### DIFF
--- a/build/update.js
+++ b/build/update.js
@@ -19,15 +19,27 @@ var keybindingdir =  path.join(braceroot, 'keybinding');
 var workersrcdir  =  path.join(braceroot, 'workersrc');
 var workerdir     =  path.join(braceroot, 'worker');
 var buildroot     =  path.join(__dirname, 'ace-build');
+var acesrcdir     =  path.join(braceroot, 'node_modules/ace');
 
 var aceTag = 'v1.2.6';
 
 +function updateCleanAndPutInOrder() {
-
-  +function cloneFreshAndRemoveUnneeded() {
+  +function buildAce() {
+    if (!fs.existsSync(acesrcdir)) return;
+    console.log("Building from Ace source");
     rm('-rf', buildroot)
+    exec('mkdir ' + buildroot);
+    exec('(cd ' + acesrcdir + ' && node ./Makefile.dryice.js full --target ' + buildroot + ')');
+  }()
+  +function cloneFresh() {
+    if (fs.existsSync(acesrcdir)) return;
+    console.log("Building from Ace Build repository");
+    rm('-rf', buildroot);
     exec('git clone git://github.com/ajaxorg/ace-builds.git ' + buildroot);
     exec('(cd ' + buildroot + ' && git pull && git checkout ' + aceTag + ')');
+  }()
+  +function removeUnneeded() {
+    exec('(cd ' + buildroot + ')');
 
     [ 'demo', 'kitchen-sink', 'src-min', 'src', 'textarea' ]
       .forEach(function (dir) { rm('-rf', path.join(buildroot, dir)) })

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "typings": "index.d.ts",
   "scripts": {
     "update": "(cd build && node ./update && node ./update-ts)",
+    "updatejs": "(cd build && node ./update)",
+    "updatets": "(cd build && node ./update-ts)",
     "test": "browserify test/*.js > test/bundle.js --debug && opener test/index.html"
   },
   "repository": {


### PR DESCRIPTION
Adds the option to build from Ace source rather than the ace-builds repo, which makes it much easier to debug ace in an app that requires brace.

To use the local/custom version of ace, run

    npm link /path/to/ace

Note that the output will not be quite the same as obtained from ace-builds, but that appears to be an issue with ace-builds not removing files that no longer exist in the source.