### PR TITLE
Add definition for define()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,13 @@ export function         createEditSession(text: Document, mode: TextMode): IEdit
         **/
 export function         createEditSession(text: string, mode: TextMode): IEditSession;
 
+        /**
+         * Defines a new module in packed noconflict mode
+         * @param name 
+         * @param dependencies 
+         * @param module 
+         */
+export function         define(name: string, dependencies: string[], module: any): void;
 
     ////////////////
     /// Anchor


### PR DESCRIPTION
I've added a TypeScript definition for the `define()` method in ace. I'm using this method to define a custom mode and include it.

Example custom mode declaration:

```typescript
import 'brace/mode/abc'; // of course you can extend whatever mode you want
import * as ace from 'brace';
let AbcMode: { new(): any } = ace.acequire('ace/mode/abc').Mode;

export const modeName = 'my-custom-mode';
export default class MyCustomMode extends AbcMode {
    constructor() {
        super();
    }
}
ace.define(modeName, [], { Mode: MyCustomMode });
```
The mode can then simply be imported as follows:

```typescript
import * as ace from 'brace';
import { modeName } from './my-custom-mode';

let editor = ace.edit(element);
let session = editor.getSession();
session.setMode(modeName);
```