### PR TITLE
Update VirtualRenderer.setStyle type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2975,8 +2975,9 @@ export function         createEditSession(text: string, mode: TextMode): IEditSe
         /**
          * [Adds a new class, `style`, to the editor.]{: #VirtualRenderer.setStyle}
          * @param style A class name
+         * @param include Adds class if true, removes class if false (optional)
         **/
-        setStyle(style: string): void;
+        setStyle(style: string, include?: boolean): void;
 
         /**
          * [Removes the class `style` from the editor.]{: #VirtualRenderer.unsetStyle}


### PR DESCRIPTION
Discovered that VirtualRenderer.setStyle type does not match actual ace function parameters.
`include(optional)` is missing.

https://ajaxorg.github.io/ace-api-docs/classes/Ace.VirtualRenderer.html#setStyle

Note that this functional signature is different from that of [Editor.setStyle](https://ajaxorg.github.io/ace-api-docs/classes/Ace.Editor.html#setStyle) 
(which actually calls VirtualRenderer.setStyle, so is kind of weird)
